### PR TITLE
fix(hyperliquid): log warning and skip malformed spot markets

### DIFF
--- a/python/ccxt/async_support/hyperliquid.py
+++ b/python/ccxt/async_support/hyperliquid.py
@@ -587,6 +587,7 @@ class hyperliquid(Exchange, ImplicitAPI):
         meta = self.safe_list(first, 'universe', [])
         tokens = self.safe_list(first, 'tokens', [])
         markets = []
+        skipped_malformed = 0
         for i in range(0, len(meta)):
             market = self.safe_dict(meta, i, {})
             index = self.safe_integer(market, 'index')
@@ -611,6 +612,21 @@ class hyperliquid(Exchange, ImplicitAPI):
             quoteId = self.safe_string(quoteTokenInfo, 'name')
             base = self.safe_currency_code(baseName)
             quote = self.safe_currency_code(quoteId)
+            if base is None or quote is None:
+                # Hyperliquid spot universe has been observed returning entries
+                # with a null token `name` (so baseName/quoteId resolve to None
+                # and `base + '/' + quote` would raise TypeError, aborting
+                # load_markets and silently freezing the freqtrade worker).
+                # Skipping (with a loud warning) keeps the client alive on the
+                # remaining markets. Investigate upstream and remove this skip
+                # if Hyperliquid has fixed it.
+                self.logger.warning(
+                    "hyperliquid fetch_spot_markets: skipping malformed spot "
+                    "universe entry index=%s name=%r baseName=%r quoteId=%r",
+                    index, marketName, baseName, quoteId,
+                )
+                skipped_malformed += 1
+                continue
             symbol = base + '/' + quote
             innerBaseTokenInfo = self.safe_dict(baseTokenInfo, 'spec', baseTokenInfo)
             # innerQuoteTokenInfo = self.safe_dict(quoteTokenInfo, 'spec', quoteTokenInfo)
@@ -676,6 +692,12 @@ class hyperliquid(Exchange, ImplicitAPI):
                 'created': None,
                 'info': self.extend(extraData, market),
             }))
+        if skipped_malformed > 0:
+            self.logger.warning(
+                "hyperliquid fetch_spot_markets: skipped %d/%d malformed spot "
+                "universe entries (see WARNING lines above)",
+                skipped_malformed, len(meta),
+            )
         return markets
 
     def parse_market(self, market: dict) -> Market:

--- a/python/ccxt/hyperliquid.py
+++ b/python/ccxt/hyperliquid.py
@@ -586,6 +586,7 @@ class hyperliquid(Exchange, ImplicitAPI):
         meta = self.safe_list(first, 'universe', [])
         tokens = self.safe_list(first, 'tokens', [])
         markets = []
+        skipped_malformed = 0
         for i in range(0, len(meta)):
             market = self.safe_dict(meta, i, {})
             index = self.safe_integer(market, 'index')
@@ -610,6 +611,21 @@ class hyperliquid(Exchange, ImplicitAPI):
             quoteId = self.safe_string(quoteTokenInfo, 'name')
             base = self.safe_currency_code(baseName)
             quote = self.safe_currency_code(quoteId)
+            if base is None or quote is None:
+                # Hyperliquid spot universe has been observed returning entries
+                # with a null token `name` (so baseName/quoteId resolve to None
+                # and `base + '/' + quote` would raise TypeError, aborting
+                # load_markets and silently freezing the freqtrade worker).
+                # Skipping (with a loud warning) keeps the client alive on the
+                # remaining markets. Investigate upstream and remove this skip
+                # if Hyperliquid has fixed it.
+                self.logger.warning(
+                    "hyperliquid fetch_spot_markets: skipping malformed spot "
+                    "universe entry index=%s name=%r baseName=%r quoteId=%r",
+                    index, marketName, baseName, quoteId,
+                )
+                skipped_malformed += 1
+                continue
             symbol = base + '/' + quote
             innerBaseTokenInfo = self.safe_dict(baseTokenInfo, 'spec', baseTokenInfo)
             # innerQuoteTokenInfo = self.safe_dict(quoteTokenInfo, 'spec', quoteTokenInfo)
@@ -675,6 +691,12 @@ class hyperliquid(Exchange, ImplicitAPI):
                 'created': None,
                 'info': self.extend(extraData, market),
             }))
+        if skipped_malformed > 0:
+            self.logger.warning(
+                "hyperliquid fetch_spot_markets: skipped %d/%d malformed spot "
+                "universe entries (see WARNING lines above)",
+                skipped_malformed, len(meta),
+            )
         return markets
 
     def parse_market(self, market: dict) -> Market:


### PR DESCRIPTION
## Summary
- Mirror PR #4 (aster) for hyperliquid: guard `symbol = base + '/' + quote` in `fetch_spot_markets` against null token names, log a WARNING with the offending entry, increment a counter, continue.
- Apply identical fix to both sync (`python/ccxt/hyperliquid.py`) and async (`python/ccxt/async_support/hyperliquid.py`) generated files.
- Emit a post-loop summary line if any entries were skipped, so we can grep for `skipped_malformed` and notice when the upstream API has been corrected.

## Context
On 2026-05-29 ~15:54 UTC, Hyperliquid added spot entry `@367` (index 367) whose token had a null `name`. ccxt's `safe_string` returned None, `safe_currency_code(None)` returned None, then `None + '/' + 'USDC'` raised `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'`. The unhandled exception aborted `load_markets` and silently froze 5 freqtrade workers across the trading farm — same failure shape as the aster incident that PR #4 fixed.

## Notes
- Python-only edit, not transpiled from TypeScript. Same convention as PR #4.
- `parse_market` (called from the swap path, not spot) is NOT patched — it has hardcoded `quoteId='USDC'` so the None branch can't fire there, and patching would mute a different real bug if HL ever emits a malformed perp.

## Test plan
- [x] `python -c "import ccxt.hyperliquid, ccxt.async_support.hyperliquid"` — imports cleanly
- [x] Deployed to 5 hyperliquid freqtrade bots in production — all 5 now log `WARNING - hyperliquid fetch_spot_markets: skipping malformed spot universe entry index=367 name='@367' baseName=None quoteId='USDC'` and continue trading normally
- [x] Recovered 21 open positions that had been silent-dead since 2026-05-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)